### PR TITLE
Bugfix 32bit limit

### DIFF
--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -335,7 +335,7 @@ class DbSizeCommand extends CommandBase
      * @return int Estimated usage in bytes
      */
     private function getPgSqlUsage(HostInterface $host, array $database) {
-        return (int) $host->runCommand($this->getPsqlCommand($database), true, true, $this->psqlQuery());
+        return (float) $host->runCommand($this->getPsqlCommand($database), true, true, $this->psqlQuery());
     }
 
     /**
@@ -368,7 +368,7 @@ class DbSizeCommand extends CommandBase
 
         $otherSizes = $host->runCommand($this->getMysqlCommand($database), true, true, $this->mysqlNonInnodbQuery((bool) $allocatedSizeSupported));
 
-        return (int) $otherSizes + (int) $innoDbSize;
+        return (float) $otherSizes + (float) $innoDbSize;
     }
 
     /**


### PR DESCRIPTION
PHP_MAX_INT = 2147483647 (2GB) on 32Bit systems. PHP Internally casts to float if the number is higher, but we casted to (int) cutting off everything to that max on 32bit systems.